### PR TITLE
Manifest for Chrome & Build fixed.

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -20,12 +20,18 @@
         "*://turntable.fm/copyright",
         "*://turntable.fm/terms",
         "*://turntable.fm/static/*",
-        "*://deepcut.fm/about",
-        "*://deepcut.fm/jobs",
-        "*://deepcut.fm/privacy",
-        "*://deepcut.fm/copyright",
-        "*://deepcut.fm/terms",
-        "*://deepcut.fm/static/*"
+        "*://deepcuts.fm/about",
+        "*://deepcuts.fm/jobs",
+        "*://deepcuts.fm/privacy",
+        "*://deepcuts.fm/copyright",
+        "*://deepcuts.fm/terms",
+        "*://deep-cuts.fm/static/*",
+        "*://deep-cuts.fm/about",
+        "*://deep-cuts.fm/jobs",
+        "*://deep-cuts.fm/privacy",
+        "*://deep-cuts.fm/copyright",
+        "*://deep-cuts.fm/terms",
+        "*://deep-cuts.fm/static/*"
       ],
       "js": [
         "inject.js"
@@ -33,7 +39,8 @@
       "run_at": "document_end",
       "matches": [
         "*://turntable.fm/*",
-        "*://deepcut.fm/*"
+        "*://deepcuts.fm/*",
+        "*://deep-cuts.fm/*"
       ]
     }
   ],

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -20,12 +20,18 @@
         "*://turntable.fm/copyright",
         "*://turntable.fm/terms",
         "*://turntable.fm/static/*",
-        "*://deepcut.fm/about",
-        "*://deepcut.fm/jobs",
-        "*://deepcut.fm/privacy",
-        "*://deepcut.fm/copyright",
-        "*://deepcut.fm/terms",
-        "*://deepcut.fm/static/*"
+        "*://deepcuts.fm/about",
+        "*://deepcuts.fm/jobs",
+        "*://deepcuts.fm/privacy",
+        "*://deepcuts.fm/copyright",
+        "*://deepcuts.fm/terms",
+        "*://deep-cuts.fm/static/*",
+        "*://deep-cuts.fm/about",
+        "*://deep-cuts.fm/jobs",
+        "*://deep-cuts.fm/privacy",
+        "*://deep-cuts.fm/copyright",
+        "*://deep-cuts.fm/terms",
+        "*://deep-cuts.fm/static/*"
       ],
       "js": [
         "inject.js"
@@ -33,7 +39,8 @@
       "run_at": "document_end",
       "matches": [
         "*://turntable.fm/*",
-        "*://deepcut.fm/*"
+        "*://deepcuts.fm/*",
+        "*://deep-cuts.fm/*"
       ]
     }
   ],


### PR DESCRIPTION
When the manifest for deepcuts.fm was added, a typo was made on both "chrome" and "build" folder, which refrained the extension from working.

However this will now fix these issues, whether the user goes to deep-cuts.fm or deepcuts.fm, and has fixed the extension from not working. I did test this before submitting the pull request, and can confirm it does work.

![image](https://github.com/pixelcrisis/turnstyles/assets/20268209/f2807dc2-1218-447d-abc2-e71c2855689b)
