### PR TITLE
Manifest.json change once again.

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -25,13 +25,20 @@
         "*://deepcuts.fm/privacy",
         "*://deepcuts.fm/copyright",
         "*://deepcuts.fm/terms",
-        "*://deep-cuts.fm/static/*",
-        "*://deep-cuts.fm/about",
-        "*://deep-cuts.fm/jobs",
-        "*://deep-cuts.fm/privacy",
-        "*://deep-cuts.fm/copyright",
-        "*://deep-cuts.fm/terms",
-        "*://deep-cuts.fm/static/*"
+        "*://deep-cut.fm/static/*",
+        "*://deep-cut.fm/static/*",
+        "*://deep-cut.fm/about",
+        "*://deep-cut.fm/jobs",
+        "*://deep-cut.fm/privacy",
+        "*://deep-cut.fm/copyright",
+        "*://deep-cut.fm/terms",
+        "*://deep-cut.fm/static/*",
+        "*://deepcut.fm/about",
+        "*://deepcut.fm/jobs",
+        "*://deepcut.fm/privacy",
+        "*://deepcut.fm/copyright",
+        "*://deepcut.fm/terms",
+        "*://deepcut.fm/static/*"
       ],
       "js": [
         "inject.js"
@@ -40,7 +47,8 @@
       "matches": [
         "*://turntable.fm/*",
         "*://deepcuts.fm/*",
-        "*://deep-cuts.fm/*"
+        "*://deep-cut.fm/*",
+        "*://deepcut.fm/*"
       ]
     }
   ],

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -47,7 +47,8 @@
       "matches": [
         "*://turntable.fm/*",
         "*://deepcuts.fm/*",
-        "*://deep-cuts.fm/*"
+        "*://deep-cut.fm/*",
+        "*://deepcut.fm/*"
       ]
     }
   ],

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -25,13 +25,20 @@
         "*://deepcuts.fm/privacy",
         "*://deepcuts.fm/copyright",
         "*://deepcuts.fm/terms",
-        "*://deep-cuts.fm/static/*",
-        "*://deep-cuts.fm/about",
-        "*://deep-cuts.fm/jobs",
-        "*://deep-cuts.fm/privacy",
-        "*://deep-cuts.fm/copyright",
-        "*://deep-cuts.fm/terms",
-        "*://deep-cuts.fm/static/*"
+        "*://deep-cut.fm/static/*",
+        "*://deep-cut.fm/static/*",
+        "*://deep-cut.fm/about",
+        "*://deep-cut.fm/jobs",
+        "*://deep-cut.fm/privacy",
+        "*://deep-cut.fm/copyright",
+        "*://deep-cut.fm/terms",
+        "*://deep-cut.fm/static/*",
+        "*://deepcut.fm/about",
+        "*://deepcut.fm/jobs",
+        "*://deepcut.fm/privacy",
+        "*://deepcut.fm/copyright",
+        "*://deepcut.fm/terms",
+        "*://deepcut.fm/static/*"
       ],
       "js": [
         "inject.js"


### PR DESCRIPTION
So it looks like recently deepcut.fm (formerly turntable.fm) are doing domain changes again, and now instead of deep-cuts.fm, It's only deepcuts.fm, deepcut.fm, & deep-cut.fm. They recently turned off deep-cuts.fm, which I do not understand why they just did this.

With deepcut.fm and deep-cut.fm being new domains that are up and can be entered into the URL bar, taking you to the website.