### PR TITLE
Domain Update for Deepcut.fm --> deepcut.live

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 </h1>
 
 <p align="center">
-  A Chrome Extension & Bookmarklet for deepcut.fm
-  <br>Apply tweaks to deepcut.fm - autobop, autodj, themes, styles, and more!
+  A Chrome Extension & Bookmarklet for deepcut.live
+  <br>Apply tweaks to deepcut.live - autobop, autodj, themes, styles, and more!
 </p>
 
 <p align="center">

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "turnStyles for deepcut.fm",
+  "name": "turnStyles for deepcut.live",
   "version": "11.0.2",
-  "description": "Apply tweaks to deepcut.fm - autobop, autodj, themes, styles, and more!",
+  "description": "Apply tweaks to deepcut.live - autobop, autodj, themes, styles, and more!",
   "manifest_version": 2,
   "icons": {
     "48": "images/icon48.png",
@@ -38,7 +38,13 @@
         "*://deepcut.fm/privacy",
         "*://deepcut.fm/copyright",
         "*://deepcut.fm/terms",
-        "*://deepcut.fm/static/*"
+        "*://deepcut.fm/static/*",
+        "*://deepcut.live/about",
+        "*://deepcut.live/jobs",
+        "*://deepcut.live/privacy",
+        "*://deepcut.live/copyright",
+        "*://deepcut.live/terms",
+        "*://deepcut.live/static/*"
       ],
       "js": [
         "inject.js"
@@ -48,7 +54,8 @@
         "*://turntable.fm/*",
         "*://deepcuts.fm/*",
         "*://deep-cut.fm/*",
-        "*://deepcut.fm/*"
+        "*://deepcut.fm/*",
+        "*://deepcut.live/*"
       ]
     }
   ],

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "turnStyles for deepcut.fm",
+  "name": "turnStyles for deepcut.live",
   "version": "11.0.2",
-  "description": "Apply tweaks to deepcut.fm - autobop, autodj, themes, styles, and more!",
+  "description": "Apply tweaks to deepcut.live - autobop, autodj, themes, styles, and more!",
   "manifest_version": 2,
   "icons": {
     "48": "images/icon48.png",
@@ -38,7 +38,13 @@
         "*://deepcut.fm/privacy",
         "*://deepcut.fm/copyright",
         "*://deepcut.fm/terms",
-        "*://deepcut.fm/static/*"
+        "*://deepcut.fm/static/*",
+        "*://deepcut.live/about",
+        "*://deepcut.live/jobs",
+        "*://deepcut.live/privacy",
+        "*://deepcut.live/copyright",
+        "*://deepcut.live/terms",
+        "*://deepcut.live/static/*"
       ],
       "js": [
         "inject.js"
@@ -48,7 +54,8 @@
         "*://turntable.fm/*",
         "*://deepcuts.fm/*",
         "*://deep-cut.fm/*",
-        "*://deepcut.fm/*"
+        "*://deepcut.fm/*",
+        "*://deepcut.live/*"
       ]
     }
   ],


### PR DESCRIPTION
Once again, Deepcut has updated they're domains, I will continue to try and maintain deepcut.live chrome extension as much as I can.